### PR TITLE
Use relative path for executing tests

### DIFF
--- a/plugin/make-test.vim
+++ b/plugin/make-test.vim
@@ -5,7 +5,7 @@ endif
 let g:loaded_make_test = 1
 
 function MakeTestFileLine()
-  let path=@%
+  let path=RelativePath(@%)
   let lineNumber=line('.') + 1
 
   let cmd="make test FILE=".path.':'.lineNumber
@@ -22,7 +22,7 @@ function MakeTestFileLine()
 endfunction
 
 function MakeTestFile()
-  let path=@%
+  let path=RelativePath(@%)
 
   let cmd="make test FILE=".path
 
@@ -35,6 +35,14 @@ function MakeTestFile()
   " switch back to last window
   au BufDelete <buffer> wincmd p
   startinsert
+endfunction
+
+function! RelativePath(filepath)
+  let l:absolute_path = fnamemodify(a:filepath, ':p')
+  let l:cwd = getcwd()
+  let l:rel_path = substitute(l:absolute_path, '^' . l:cwd . '/', '', '')
+
+  return l:rel_path
 endfunction
 
 command! -bar MakeTestFileLine call MakeTestFileLine()


### PR DESCRIPTION
If you are running your tests with Docker, for example by setting the `make test` to:

```
test:
  docker-compose run app mix test $(FILE)
```

Then it is quite useful to only pass the relative path from the project root, instead of passing the full absolute path that might not exists in the docker image, example:

```
# On my local development machine
/Users/dev/operately/test/operately_test.ex

# This path is mounted in the docker image as
/home/app/operately/test/operately_test.ex
```

If we pass the relative path, we avoid dealing with this problem, as it will only pass the `test/operately_test.ex` path to the make target.